### PR TITLE
Starting map added

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # PV239 Mobile application development - Brno Tourist App
 ![kotlin-version](https://img.shields.io/badge/kotlin-1.8.0-orange) 
 # Project: Brno tourist app
+[Project specification](https://docs.google.com/document/d/1iPUjf_It66s5Jng1KD_YH_o_vDsHilqqXWHT4eZJWhw/edit?usp=sharing)
 [Data source link](https://data.brno.cz/datasets/mestobrno::turistick%C3%A9-okruhy-popular-tourist-routes/explore?location=49.198311%2C16.617438%2C13.00)
 # Phase 1 *deadline 6. 3. 2023 - Specification of Project
 * **Team:** Illia Kostenko,  Alina Tsykynovska, Max Vagner.
 * **Language:** Kotlin.
 * [x] [Illia]: Create specification of the project
 * [x] [Illia]: Create Figma demo
-# Phase 2 *deadline 27. 3. 2023 - 1st Control of project
+# Phase 2 *deadline 17. 4. 2023 - 1st Control of project
 * [x] [Illia]: Create repository of project
 * [ ] [Alina]: Create start page
 * [ ] [Alina]: Create fragment of carousel
@@ -15,7 +16,7 @@
 * [ ] [Max]: Create button of GPS
 * [ ] [Max]: Create map page
 * [ ] [Illia]: Import data to the local DB (Room?)
-# Phase 3 *deadline 17. 4. 2023 - 2nd Control of project
+# Phase 3 *deadline 24. 4. 2023 - 2nd Control of project
 * [ ] []:Create navigation to the map dialog window
 * [ ] []: Connect GPS action with map component
 * [ ] []: Connect app to the DB
@@ -25,5 +26,7 @@
 * [ ] []: Add info message without internet (disable GPS and set default area at the map)
 * [ ] []: 
 * [ ] []: Prepare presentation
-# Phase 4 *deadline 8. 5. 2023 - Send project to control
-* [ ] []: Prepare presentation
+# Phase 4 *deadline 12. 5. 2023 - Send project to control
+# Phase 5 *deadline 6. 6. 2023 - Final closing
+* [ ] []: Monitor the feedback
+* [ ] []: Prepare the presentation

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+    id 'androidx.navigation.safeargs'
 }
 
 android {
@@ -38,11 +39,15 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'io.coil-kt:coil:2.3.0'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,11 @@
         android:theme="@style/Theme.BrnoTouristApp"
         tools:targetApi="31">
         <activity
+            android:name=".MainActivity"
+            android:exported="false"
+            android:label="@string/title_activity_main"
+            android:theme="@style/Theme.BrnoTouristApp.NoActionBar" />
+        <activity
             android:name=".WelcomeActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,12 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.BrnoTouristApp"
         tools:targetApi="31">
@@ -25,12 +27,12 @@
         -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="YOUR_API_KEY" />
+            android:value="${MAPS_API_KEY}" />
 
         <activity
             android:name=".MapsActivity"
             android:exported="true"
-            android:label="@string/title_activity_maps">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -13,7 +13,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BrnoTouristApp"
         tools:targetApi="31">
+        <activity
+            android:name=".WelcomeActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="true"
+            android:label="@string/title_activity_welcome"
+            android:theme="@style/Theme.BrnoTouristApp.Fullscreen">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <!--
              TODO: Before you run your application, you need a Google Maps API key.
 
@@ -35,8 +46,6 @@
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/pv239/brnotouristapp/DiscoverFragment.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/DiscoverFragment.kt
@@ -1,0 +1,85 @@
+package com.pv239.brnotouristapp
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.pv239.brnotouristapp.databinding.FragmentDiscoverBinding
+
+
+class DiscoverFragment : Fragment() {
+
+    private var _binding: FragmentDiscoverBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    private val districtRepository = DistrictRepository()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+
+        _binding = FragmentDiscoverBinding.inflate(inflater, container, false)
+
+        districtRepository.loadDistricts()
+
+        val districtList: RecyclerView = binding.districtList
+        districtList.layoutManager =
+            LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        val districtListAdapter = DistrictListAdapter{district -> districtClicked(district)}
+        districtList.adapter = districtListAdapter
+        val districtListObserver = Observer<List<District>> {
+            districtListAdapter.submitList(it)
+        }
+        districtRepository.districtList.observe(viewLifecycleOwner, districtListObserver)
+
+        return binding.root
+
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.buttonShowLocation.setOnClickListener { showAlertDialog(requireContext()) }
+    }
+
+    private fun districtClicked(district: District){
+        //TODO what happens on district click
+        Unit
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun showAlertDialog(context : Context){
+        val builder = AlertDialog.Builder(context)
+        builder.setTitle("Are you sure?")
+            .setMessage("You will share your GPS data!")
+
+        builder.setPositiveButton(R.string.confirm) { dialogInterface: DialogInterface, i: Int ->
+            findNavController().navigate(R.id.action_DiscoverFragment_to_MapFragment)
+            dialogInterface.dismiss()
+        }
+
+        builder.setNegativeButton(R.string.cancel) { dialogInterface: DialogInterface, i: Int ->
+            dialogInterface.cancel()
+        }
+
+        builder.create()
+        builder.show()
+    }
+
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/District.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/District.kt
@@ -1,0 +1,8 @@
+package com.pv239.brnotouristapp
+
+data class District(
+    val name: String,
+    val imageUrl: String,
+    val lat: Double,
+    val lng: Double
+)

--- a/app/src/main/java/com/pv239/brnotouristapp/DistrictListAdapter.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/DistrictListAdapter.kt
@@ -1,0 +1,54 @@
+package com.pv239.brnotouristapp
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+
+class DistrictViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    private val districtTextView: TextView = view.findViewById(R.id.districtTextView)
+    private val districtImageView: ImageView = view.findViewById(R.id.districtImageView)
+
+    fun bind(district: District) {
+        districtTextView.text = district.name
+        districtImageView.load(district.imageUrl)
+    }
+}
+
+class DistrictListAdapter(
+    private val clickHandler: (District) -> Unit // Unit = void
+) : ListAdapter<District, DistrictViewHolder>(DIFF_CONFIG) {
+
+    companion object {
+        val DIFF_CONFIG = object : DiffUtil.ItemCallback<District>() {
+            override fun areItemsTheSame(oldItem: District, newItem: District): Boolean {
+                return oldItem === newItem // === - do oldItem and newItem have the exact object reference?
+            }
+
+            override fun areContentsTheSame(
+                oldItem: District,
+                newItem: District
+            ): Boolean {
+                return oldItem == newItem // == - are their contents same? (don't need to be the same object)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DistrictViewHolder {
+        val itemView =
+            LayoutInflater.from(parent.context).inflate(R.layout.district_item, parent, false)
+        return DistrictViewHolder(itemView)
+    }
+
+    override fun onBindViewHolder(holder: DistrictViewHolder, position: Int) {
+        holder.bind(getItem(position))
+        holder.itemView.setOnClickListener {
+            clickHandler(getItem(position))
+        }
+    }
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/DistrictRepository.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/DistrictRepository.kt
@@ -1,0 +1,58 @@
+package com.pv239.brnotouristapp
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
+class DistrictRepository {
+
+    private val _districtList = MutableLiveData<List<District>>()
+    val districtList: LiveData<List<District>> = _districtList
+
+    fun loadDistricts() {
+        val exampleDistricts = listOf(
+            District(
+                "Střed",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.1879143,
+                16.5601508
+            ),
+            District(
+                "Řečkovice",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.2487669,
+                16.5727728
+            ),
+            District(
+                "Líšeň",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.215067,
+                16.6591306
+            ),
+            District(
+                "Královo Pole",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.2273492,
+                16.5778692
+            ),
+            District(
+                "Vinohrady",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.2075479,
+                16.6559426
+            ),
+            District(
+                "Bystrc",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.226408,
+                16.5223052
+            ),
+            District(
+                "Bohunice",
+                "https://www.mistopisy.cz/modules/pruvodce/media/village/9136/nature.jpg",
+                49.1703593,
+                16.5699176
+            )
+        )
+        _districtList.value = exampleDistricts
+    }
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/MainActivity.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/MainActivity.kt
@@ -1,0 +1,35 @@
+package com.pv239.brnotouristapp
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.navigateUp
+import androidx.navigation.ui.setupActionBarWithNavController
+import com.pv239.brnotouristapp.databinding.ActivityMainBinding
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var appBarConfiguration: AppBarConfiguration
+    private lateinit var binding: ActivityMainBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+
+        val navController = findNavController(R.id.nav_host_fragment_content_main)
+        appBarConfiguration = AppBarConfiguration(navController.graph)
+        setupActionBarWithNavController(navController, appBarConfiguration)
+
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navController = findNavController(R.id.nav_host_fragment_content_main)
+        return navController.navigateUp(appBarConfiguration)
+                || super.onSupportNavigateUp()
+    }
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/MapFragment.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/MapFragment.kt
@@ -1,0 +1,91 @@
+package com.pv239.brnotouristapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.MapView
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+import com.pv239.brnotouristapp.databinding.FragmentMapBinding
+
+/**
+ * A simple [Fragment] subclass as the second destination in the navigation.
+ */
+class MapFragment : Fragment(), OnMapReadyCallback {
+
+    private lateinit var mMap: GoogleMap
+    private val districtRepository = DistrictRepository()
+
+    private var _binding: FragmentMapBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentMapBinding.inflate(inflater, container, false)
+
+        view?.findViewById<MapView>(R.id.map)?.getMapAsync(this)
+
+        districtRepository.loadDistricts()
+
+        binding.districtList.layoutManager =
+            LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        val districtListAdapter = DistrictListAdapter {
+            mMap.animateCamera(
+                CameraUpdateFactory.newCameraPosition(
+                    CameraPosition.Builder()
+                        .target(LatLng(it.lat, it.lng))
+                        .zoom(12.5f)
+                        .tilt(30f)
+                        .build()
+                )
+            )
+        }
+
+        binding.districtList.adapter = districtListAdapter
+
+        val districtListObserver = Observer<List<District>> {
+            districtListAdapter.submitList(it)
+        }
+        districtRepository.districtList.observe(requireActivity(), districtListObserver)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        mMap = googleMap
+
+        // Add a marker in Sydney and move the camera
+        val brno = LatLng(49.195061, 16.606836)
+        mMap.addMarker(MarkerOptions().position(brno).title("Marker in Brno"))
+//        mMap.moveCamera(CameraUpdateFactory.newLatLng(brno))
+        val cameraPosition = CameraPosition.Builder()
+            .target(brno)
+            .zoom(12.5f)
+            .tilt(30f)
+            .build()
+        mMap.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition))
+    }
+
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/MapsActivity.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/MapsActivity.kt
@@ -1,12 +1,16 @@
 package com.pv239.brnotouristapp
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.pv239.brnotouristapp.databinding.ActivityMapsBinding
@@ -15,6 +19,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private lateinit var mMap: GoogleMap
     private lateinit var binding: ActivityMapsBinding
+    private val districtRepository = DistrictRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,6 +31,29 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         val mapFragment = supportFragmentManager
             .findFragmentById(R.id.map) as SupportMapFragment
         mapFragment.getMapAsync(this)
+
+        districtRepository.loadDistricts()
+
+        val districtList: RecyclerView = findViewById(R.id.districtList)
+        districtList.layoutManager =
+            LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
+        val districtListAdapter = DistrictListAdapter {
+            mMap.animateCamera(
+                CameraUpdateFactory.newCameraPosition(
+                    CameraPosition.Builder()
+                        .target(LatLng(it.lat, it.lng))
+                        .zoom(12.5f)
+                        .tilt(30f)
+                        .build()
+                )
+            )
+        }
+        districtList.adapter = districtListAdapter
+
+        val districtListObserver = Observer<List<District>> {
+            districtListAdapter.submitList(it)
+        }
+        districtRepository.districtList.observe(this, districtListObserver)
     }
 
     /**
@@ -41,8 +69,15 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         mMap = googleMap
 
         // Add a marker in Sydney and move the camera
-        val sydney = LatLng(-34.0, 151.0)
-        mMap.addMarker(MarkerOptions().position(sydney).title("Marker in Sydney"))
-        mMap.moveCamera(CameraUpdateFactory.newLatLng(sydney))
+        val brno = LatLng(49.195061, 16.606836)
+        mMap.addMarker(MarkerOptions().position(brno).title("Marker in Brno"))
+//        mMap.moveCamera(CameraUpdateFactory.newLatLng(brno))
+        val cameraPosition = CameraPosition.Builder()
+            .target(brno)
+            .zoom(12.5f)
+            .tilt(30f)
+            .build()
+        mMap.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition))
     }
+
 }

--- a/app/src/main/java/com/pv239/brnotouristapp/Place.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/Place.kt
@@ -1,0 +1,10 @@
+package com.pv239.brnotouristapp
+
+data class Place(
+    val name: String,
+    val lat: Double,
+    val lng: Double,
+    val address: String,
+    val imageUrl: String,
+    val description: String
+)

--- a/app/src/main/java/com/pv239/brnotouristapp/PlaceDetails.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/PlaceDetails.kt
@@ -1,0 +1,22 @@
+package com.pv239.brnotouristapp
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class PlaceDetails : Fragment() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_place_details, container, false)
+    }
+}

--- a/app/src/main/java/com/pv239/brnotouristapp/WelcomeActivity.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/WelcomeActivity.kt
@@ -28,7 +28,7 @@ class WelcomeActivity : AppCompatActivity() {
         fullscreenContent = binding.fullscreenContent
 
         Handler().postDelayed({
-            val intent = Intent(this, MapsActivity::class.java)
+            val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()
         }, SPLASH_DELAY)

--- a/app/src/main/java/com/pv239/brnotouristapp/WelcomeActivity.kt
+++ b/app/src/main/java/com/pv239/brnotouristapp/WelcomeActivity.kt
@@ -1,0 +1,37 @@
+package com.pv239.brnotouristapp
+
+import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.pv239.brnotouristapp.databinding.ActivityWelcomeBinding
+
+class WelcomeActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityWelcomeBinding
+    private lateinit var fullscreenContent: TextView
+    private var isFullscreen: Boolean = false
+    private val SPLASH_DELAY: Long = 2000
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityWelcomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        isFullscreen = true
+
+        supportActionBar?.hide()
+        fullscreenContent = binding.fullscreenContent
+
+        Handler().postDelayed({
+            val intent = Intent(this, MapsActivity::class.java)
+            startActivity(intent)
+            finish()
+        }, SPLASH_DELAY)
+    }
+
+}

--- a/app/src/main/res/drawable/baseline_image_96.xml
+++ b/app/src/main/res/drawable/baseline_image_96.xml
@@ -1,0 +1,5 @@
+<vector android:height="96dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="96dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_my_location_24.xml
+++ b/app/src/main/res/drawable/baseline_my_location_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,1h-2v2.06C6.83,3.52 3.52,6.83 3.06,11L1,11v2h2.06c0.46,4.17 3.77,7.48 7.94,7.94L11,23h2v-2.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L23,13v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Theme.BrnoTouristApp.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/Theme.BrnoTouristApp.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include layout="@layout/content_main" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -1,9 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:map="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/map"
-    android:name="com.google.android.gms.maps.SupportMapFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MapsActivity" />
+    tools:context=".MapsActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/map"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".MapsActivity"
+        tools:layout_editor_absoluteX="-16dp"
+        tools:layout_editor_absoluteY="86dp"
+        map:uiZoomControls="true"
+        map:uiCompass="true"
+        map:uiRotateGestures="true"
+        map:cameraTilt="30"
+        map:mapType="terrain"
+        />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/findLocationButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:clickable="true"
+        android:focusable="true"
+        map:layout_constraintBottom_toTopOf="@+id/relativeLayout"
+        map:layout_constraintEnd_toEndOf="parent"
+        map:layout_constraintHorizontal_bias="1.0"
+        map:layout_constraintStart_toStartOf="parent"
+        map:srcCompat="@drawable/baseline_my_location_24" />
+
+    <LinearLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="8dp"
+        map:layout_constraintBottom_toBottomOf="parent"
+        map:layout_constraintEnd_toEndOf="parent"
+        map:layout_constraintHorizontal_bias="0.5"
+        map:layout_constraintStart_toStartOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/districtList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            map:layout_constraintBottom_toBottomOf="parent"
+            map:layout_constraintEnd_toEndOf="parent"
+            map:layout_constraintStart_toStartOf="parent"
+            map:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/ThemeOverlay.BrnoTouristApp.FullscreenContainer"
+    tools:context=".WelcomeActivity">
+
+    <TextView
+        android:id="@+id/fullscreen_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:keepScreenOn="true"
+        android:text="@string/welcome_text"
+        android:textSize="50sp"
+        android:textStyle="bold" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <fragment
+        android:id="@+id/nav_host_fragment_content_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/district_item.xml
+++ b/app/src/main/res/layout/district_item.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/districtImageView"
+        android:layout_width="160dp"
+        android:layout_height="160dp"
+        android:background="@android:color/transparent"
+        android:padding="4dp"
+        android:scaleType="fitXY"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearance="@style/CornerCut"
+        tools:src="@drawable/baseline_image_96" />
+
+    <TextView
+        android:id="@+id/districtTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="District"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="@+id/districtImageView"
+        app:layout_constraintEnd_toEndOf="@+id/districtImageView"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="@+id/districtImageView" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_discover.xml
+++ b/app/src/main/res/layout/fragment_discover.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DiscoverFragment">
+
+    <LinearLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/districtList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/button_show_location"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/location"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/map"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".MainActivity"
+        tools:layout_editor_absoluteX="-16dp"
+        tools:layout_editor_absoluteY="86dp"
+        map:uiZoomControls="true"
+        map:uiCompass="true"
+        map:uiRotateGestures="true"
+        map:cameraTilt="30"
+        map:mapType="terrain"
+        />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/findLocationButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:clickable="true"
+        android:focusable="true"
+        map:layout_constraintBottom_toTopOf="@+id/relativeLayout"
+        map:layout_constraintEnd_toEndOf="parent"
+        map:layout_constraintHorizontal_bias="1.0"
+        map:layout_constraintStart_toStartOf="parent"
+        map:srcCompat="@drawable/baseline_my_location_24" />
+
+    <LinearLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="8dp"
+        map:layout_constraintBottom_toBottomOf="parent"
+        map:layout_constraintEnd_toEndOf="parent"
+        map:layout_constraintHorizontal_bias="0.5"
+        map:layout_constraintStart_toStartOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/districtList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            map:layout_constraintBottom_toBottomOf="parent"
+            map:layout_constraintEnd_toEndOf="parent"
+            map:layout_constraintStart_toStartOf="parent"
+            map:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_place_details.xml
+++ b/app/src/main/res/layout/fragment_place_details.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".PlaceDetails">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="200dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@tools:sample/backgrounds/scenic" />
+
+    <TextView
+        android:id="@+id/placeNameTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:fontFamily="casual"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display2"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageView"
+        tools:text="The Place" />
+
+    <TextView
+        android:id="@+id/placeAddressTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:fontFamily="casual"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/placeNameTextView"
+        tools:text="address" />
+
+    <TextView
+        android:id="@+id/placeDescriptionTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/placeAddressTextView"
+        app:layout_constraintVertical_bias="0.0"
+        tools:text="decription very very loooooong" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/DiscoverFragment">
+
+    <fragment
+        android:id="@+id/DiscoverFragment"
+        android:name="com.pv239.brnotouristapp.DiscoverFragment"
+        android:label="@string/discover_fragment_label"
+        tools:layout="@layout/fragment_discover">
+
+        <action
+            android:id="@+id/action_DiscoverFragment_to_MapFragment"
+            app:destination="@id/MapFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/MapFragment"
+        android:name="com.pv239.brnotouristapp.MapFragment"
+        android:label="@string/map_fragment_label"
+        tools:layout="@layout/fragment_map">
+        <action
+            android:id="@+id/action_MapFragment_to_DiscoverFragment"
+            app:destination="@id/DiscoverFragment" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,7 @@
     <color name="light_blue_A200">#FF40C4FF</color>
     <color name="light_blue_A400">#FF00B0FF</color>
     <color name="black_overlay">#66000000</color>
+    <color name="red">#66FF0000</color>
+    <color name="green">#6600FF04</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,4 +11,9 @@
     <color name="blue_30">#08458E</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="light_blue_600">#FF039BE5</color>
+    <color name="light_blue_900">#FF01579B</color>
+    <color name="light_blue_A200">#FF40C4FF</color>
+    <color name="light_blue_A400">#FF00B0FF</color>
+    <color name="black_overlay">#66000000</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,10 @@
     <color name="purple_700">#FF3700B3</color>
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
+    <color name="brown_40">#994615</color>
+    <color name="brown_30">#7A3000</color>
+    <color name="blue_40">#2E5DA8</color>
+    <color name="blue_30">#08458E</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">Brno Tourist App</string>
-    <string name="title_activity_maps">MapsActivity</string>
+    <string name="title_activity_maps">Map</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="place_details_fragment">Place Details</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="title_activity_maps">Map</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="place_details_fragment">Place Details</string>
+    <string name="title_activity_welcome">activity_welcome</string>
+    <string name="welcome_text">Touristic app</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,14 @@
     <string name="place_details_fragment">Place Details</string>
     <string name="title_activity_welcome">activity_welcome</string>
     <string name="welcome_text">Touristic app</string>
+    <string name="title_activity_main">MainActivity</string>
+    <!-- Strings used for fragments for navigation -->
+    <string name="discover_fragment_label">Discover</string>
+    <string name="map_fragment_label">Map</string>
+    <string name="location">Show my location</string>
+    <string name="previous">Previous</string>
+    <string name="confirm">Confirm</string>
+    <string name="cancel">Cancel</string>
+    <string name="hello_first_fragment">Hello first fragment</string>
+    <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,13 +2,13 @@
     <!-- Base application theme. -->
     <style name="Theme.BrnoTouristApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/brown_40</item>
-        <item name="colorPrimaryVariant">@color/brown_30</item>
+        <item name="colorPrimary">@color/blue_30</item>
+        <item name="colorPrimaryVariant">@color/light_blue_900</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/blue_40</item>
-        <item name="colorSecondaryVariant">@color/blue_30</item>
-        <item name="colorOnSecondary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_200</item>
+        <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
@@ -34,4 +34,15 @@
         <item name="android:background">@color/blue_40</item>
         <item name="android:textColor">@color/white</item>
     </style>
+
+    <style name="Theme.BrnoTouristApp.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Theme.BrnoTouristApp.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="Theme.BrnoTouristApp.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,15 +2,26 @@
     <!-- Base application theme. -->
     <style name="Theme.BrnoTouristApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorPrimary">@color/brown_40</item>
+        <item name="colorPrimaryVariant">@color/brown_30</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/blue_40</item>
+        <item name="colorSecondaryVariant">@color/blue_30</item>
+        <item name="colorOnSecondary">@color/white</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+    </style>
+
+    <style name="CornerCut" parent="">
+        <item name="cornerFamilyTopLeft">rounded</item>
+        <item name="cornerFamilyTopRight">rounded</item>
+        <item name="cornerFamilyBottomLeft">rounded</item>
+        <item name="cornerFamilyBottomRight">rounded</item>
+        <item name="cornerSizeTopLeft">10%</item>
+        <item name="cornerSizeTopRight">10%</item>
+        <item name="cornerSizeBottomLeft">10%</item>
+        <item name="cornerSizeBottomRight">10%</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,4 +24,14 @@
         <item name="cornerSizeBottomLeft">10%</item>
         <item name="cornerSizeBottomRight">10%</item>
     </style>
+
+    <style name="Theme.BrnoTouristApp.Fullscreen" parent="Theme.BrnoTouristApp">
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="android:windowBackground">@null</item>
+    </style>
+
+    <style name="ThemeOverlay.BrnoTouristApp.FullscreenContainer" parent="">
+        <item name="android:background">@color/blue_40</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        classpath('androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3')
+    }
+}
+
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
 }


### PR DESCRIPTION
Just a starting page, can (and should) be modified in any ways. The locations of districts are stubs, as well as a picture. Also created a details for a place, but haven't attached it anywhere yet.

I created some data classes for a district and a place, but they should be replaced with @friendlycoconut classes when merging everything. 

Several questions to everybody:
- Should we make a starting screen? (As in specification)
- How will we show the details page - as an another "page", or as a new window above the map?
- How will we show the districts - like it is now, or maybe with borders as [here](https://data.brno.cz/datasets/mestobrno::obecn%C3%AD-bydlen%C3%AD-po%C4%8Dty-byt%C5%AF-jednotliv%C3%BDch-druh%C5%AF-podle-m%C4%9Bstsk%C3%BDch-%C4%8D%C3%A1st%C3%AD-municipal-housing-number-of-dwellings-by-city-districts/explore?location=49.199805%2C16.583568%2C11.71), for example?

In the end, as for me, it is enough for this milestone.